### PR TITLE
Add character limit to titles

### DIFF
--- a/arcabot.py
+++ b/arcabot.py
@@ -22,5 +22,8 @@ for item in items:
   url += pid
   shorten_url = b.shorten(url)
   bitly_url = shorten_url["url"]
+  title_limit = 140 - (len(bitly_url) + 1)
+  if len(title) > title_limit:
+    title = title[:title_limit - 3] + "..."
   tweet_text = "%s %s" % (title,bitly_url)
   api.update_status(tweet_text)


### PR DESCRIPTION
Due to the random nature of the objects chosen, I couldn't quickly test a 140+ character title. But this does work with normal-length titles, so we'll see.
